### PR TITLE
openclaw-gateway: Netzwerk-Isolation aktiviert (host_network: false)

### DIFF
--- a/openclaw-gateway/CHANGELOG.md
+++ b/openclaw-gateway/CHANGELOG.md
@@ -1,5 +1,9 @@
 <!-- https://developers.home-assistant.io/docs/add-ons/presentation#keeping-a-changelog -->
 
+## 0.1.2
+
+- Change: Netzwerk-Isolation aktiviert (host_network: false)
+
 ## 0.1.1
 
 - Fix: s6 Service-Skripte (run/finish) jetzt ausführbar

--- a/openclaw-gateway/config.yaml
+++ b/openclaw-gateway/config.yaml
@@ -1,6 +1,6 @@
 # https://developers.home-assistant.io/docs/add-ons/configuration#add-on-config
 name: OpenClaw Gateway
-version: "0.1.1"
+version: "0.1.2"
 slug: openclaw-gateway
 description: OpenClaw AI Gateway — verbinde deine KI mit Home Assistant
 url: "https://github.com/ruthem/HA-Addons/tree/main/openclaw-gateway"
@@ -8,7 +8,7 @@ arch:
   - aarch64
   - amd64
 init: false
-host_network: true
+host_network: false
 hassio_api: true
 homeassistant_api: true
 map:


### PR DESCRIPTION
Der Add-on läuft jetzt isoliert im Docker-Netzwerk, hat keinen direkten Zugriff mehr auf das lokale LAN. Port 18789 wird weiterhin exponiert für externe Verbindungen.

Version: 0.1.2